### PR TITLE
Fix Kernel version compatibility issues

### DIFF
--- a/package/host/src/nrc/nrc-debug.c
+++ b/package/host/src/nrc/nrc-debug.c
@@ -320,10 +320,10 @@ static u32 bunch = 0;
 static u8 lb_subtype;
 static u32 lb_count = 1;
 u32 lb_hexdump = 0;
-ktime_t tx_time_first;
-ktime_t tx_time_last;
-ktime_t rcv_time_first;
-ktime_t rcv_time_last;
+s64 tx_time_first;
+s64 tx_time_last;
+s64 rcv_time_first;
+s64 rcv_time_last;
 u32 arv_time_first;
 u32 arv_time_last;
 struct lb_time_info *time_info_array = NULL;
@@ -555,10 +555,11 @@ static ssize_t nrc_debugfs_hspi_report_write(struct file *file, const char __use
 	return ret;
 }
 
+#define TIMESTAMP_SUB(x, y)	((x) - (y))
 #define RESET_VARS()	(c = sum_tx = sum_rx = 0)
 #define LB_INFO(x)		((time_info_array + i)->_##x)
 #define LB_INFO_(x)		((time_info_array + i - 1)->_##x)
-#define LB_SUB(x)		((unsigned long)ktime_sub(LB_INFO(x), LB_INFO_(x)))
+#define LB_SUB(x)		((unsigned long)TIMESTAMP_SUB(LB_INFO(x), LB_INFO_(x)))
 
 static int nrc_debugfs_hspi_report(struct seq_file *s, void *data)
 {
@@ -581,14 +582,14 @@ static int nrc_debugfs_hspi_report(struct seq_file *s, void *data)
 		seq_printf(s, "   => Total transferred bytes (No.3 + No.4): %llu bytes\n\n", t = (unsigned long long)(tx + rx));
 		seq_printf(s, "5. First frame transmit time: %llu us\n", tx_time_first);
 		seq_printf(s, "6. Last frame transmit time: %llu us\n", tx_time_last);
-		seq_printf(s, "   (diff: %lu us)\n", (unsigned long)ktime_sub(tx_time_last, tx_time_first));
+		seq_printf(s, "   (diff: %lu us)\n", (unsigned long)TIMESTAMP_SUB(tx_time_last, tx_time_first));
 		seq_printf(s, "7. First frame received time: %llu us\n", rcv_time_first);
 		seq_printf(s, "8. Last frame received time: %llu us\n", rcv_time_last);
-		seq_printf(s, "   (diff: %lu us)\n", (unsigned long)ktime_sub(rcv_time_last, rcv_time_first));
+		seq_printf(s, "   (diff: %lu us)\n", (unsigned long)TIMESTAMP_SUB(rcv_time_last, rcv_time_first));
 		seq_printf(s, "   --------------------------------------------\n");
-		seq_printf(s, "   => First frame RTT (No.7 - No.5) : %lu us\n", (unsigned long)ktime_sub(rcv_time_first, tx_time_first));
-		seq_printf(s, "   => Last frame RTT (No.8 - No.6) : %lu us\n", (unsigned long)ktime_sub(rcv_time_last, tx_time_last));
-		seq_printf(s, "   => Time diff (No.8 - No.5) : %lu us\n", diff = (unsigned long)ktime_sub(rcv_time_last, tx_time_first));
+		seq_printf(s, "   => First frame RTT (No.7 - No.5) : %lu us\n", (unsigned long)TIMESTAMP_SUB(rcv_time_first, tx_time_first));
+		seq_printf(s, "   => Last frame RTT (No.8 - No.6) : %lu us\n", (unsigned long)TIMESTAMP_SUB(rcv_time_last, tx_time_last));
+		seq_printf(s, "   => Time diff (No.8 - No.5) : %lu us\n", diff = (unsigned long)TIMESTAMP_SUB(rcv_time_last, tx_time_first));
 		t *= 7812; // 8(bit) / 1024(kbit) * 1000000(sec) = 7812.5
 		seq_printf(s, "   => Throughput: %llu kbps\n", div_u64(t, diff));
 	} else if (lb_subtype == LOOPBACK_MODE_TX_ONLY) {
@@ -596,7 +597,7 @@ static int nrc_debugfs_hspi_report(struct seq_file *s, void *data)
 		seq_printf(s, "3. Total tx bytes (HOST -> TARGET): %lld bytes\n\n", t = (lb_count - 1) * slots * TX_SLOT_SIZE);
 		seq_printf(s, "4. First frame transmit time: %llu us\n", tx_time_first);
 		seq_printf(s, "5. Last frame transmit time: %llu us\n", tx_time_last);
-		seq_printf(s, "   (diff: %lu us)\n", (unsigned long)ktime_sub(tx_time_last, tx_time_first));
+		seq_printf(s, "   (diff: %lu us)\n", (unsigned long)TIMESTAMP_SUB(tx_time_last, tx_time_first));
 		seq_printf(s, "6. First frame arrival time(TSF in target): %u us\n", arv_time_first);
 		seq_printf(s, "7. Last frame arrival time(TSF in target): %u us\n", arv_time_last);
 		seq_printf(s, "   (diff: %lu us)\n", diff = (arv_time_last - arv_time_first));
@@ -609,7 +610,7 @@ static int nrc_debugfs_hspi_report(struct seq_file *s, void *data)
 		seq_printf(s, "3. Total rx bytes (TARGET -> HOST): %lld bytes\n\n", t = (lb_count - 1) * rl);
 		seq_printf(s, "7. First frame received time: %llu us\n", rcv_time_first);
 		seq_printf(s, "8. Last frame received time: %llu us\n", rcv_time_last);
-		seq_printf(s, "   (diff: %lu us)\n", diff = (unsigned long)ktime_sub(rcv_time_last, rcv_time_first));
+		seq_printf(s, "   (diff: %lu us)\n", diff = (unsigned long)TIMESTAMP_SUB(rcv_time_last, rcv_time_first));
 		seq_printf(s, "   --------------------------------------------\n");
 		t *= 7812; // 8(bit) / 1024(kbit) * 1000000(sec) = 7812.5
 		seq_printf(s, "   => Throughput: %llu kbps\n", div_u64(t, diff));

--- a/package/host/src/nrc/nrc-debug.h
+++ b/package/host/src/nrc/nrc-debug.h
@@ -47,15 +47,15 @@ enum LOOPBACK_MODE {
 
 struct lb_time_info {
 	int _i;
-	ktime_t _txt;
-	ktime_t _rxt;
+	s64 _txt;
+	s64 _rxt;
 };
 
 extern unsigned long nrc_debug_mask;
-extern ktime_t tx_time_first;
-extern ktime_t tx_time_last;
-extern ktime_t rcv_time_first;
-extern ktime_t rcv_time_last;
+extern s64 tx_time_first;
+extern s64 tx_time_last;
+extern s64 rcv_time_first;
+extern s64 rcv_time_last;
 extern u32 arv_time_first;
 extern u32 arv_time_last;
 extern struct lb_time_info *time_info_array;

--- a/package/host/src/nrc/nrc-mac80211.c
+++ b/package/host/src/nrc/nrc-mac80211.c
@@ -2600,8 +2600,8 @@ int nrc_mac_suspend(struct ieee80211_hw *hw, struct cfg80211_wowlan *wowlan)
 	struct nrc_txq *ntxq;
 	struct wim_pm_param *p;
 
-	nrc_ps_dbg("[%s,L%d] any:%d patterns(0x%08x) n_patterns(%d)\n", __func__, __LINE__, 
-			wowlan->any, (int)wowlan->patterns, wowlan->n_patterns);
+	nrc_ps_dbg("[%s,L%d] any:%d patterns(%p) n_patterns(%d)\n", __func__, __LINE__, 
+			wowlan->any, wowlan->patterns, wowlan->n_patterns);
 
 	/*
 	 * If the target is already in deepsleep state(running uCode),
@@ -2666,8 +2666,12 @@ int nrc_mac_suspend(struct ieee80211_hw *hw, struct cfg80211_wowlan *wowlan)
 }
 #endif
 
+#if KERNEL_VERSION(4, 8, 0) <= NRC_TARGET_KERNEL_VERSION
 static u32 nrc_get_expected_throughput(struct ieee80211_hw *hw,
 		struct ieee80211_sta *sta)
+#else
+static u32 nrc_get_expected_throughput(struct ieee80211_sta *sta)
+#endif
 {
 	uint32_t tput = 0;
 

--- a/package/host/src/nrc/nrc-trx.c
+++ b/package/host/src/nrc/nrc-trx.c
@@ -473,11 +473,12 @@ static void nrc_mac_rx_h_status(struct nrc *nw, struct sk_buff *skb)
 	if (fh->flags.rx.iv_stripped)
 		status->flag |= RX_FLAG_IV_STRIPPED;
 
+#if KERNEL_VERSION(4, 4, 132) <= NRC_TARGET_KERNEL_VERSION
 	if(mh->frame_control & 0x0400)
 	{
 		status->flag |= RX_FLAG_ALLOW_SAME_PN;
 	}
-
+#endif
 	if (signal_monitor) {
 		//update snr and rssi only if signal monitor is enabled
 		nrc_stats_update(mh->addr2, fh->flags.rx.snr, fh->flags.rx.rssi);


### PR DESCRIPTION
Fix kernel version compatibility issues.
(1) argument of nrc_get_expected_throughput (nrc-mac80211.c)
(2) printf pointer cast (nrc-mac80211.c)
(3) Macro RX_FLAG_ALLOW_SAME_PN (nrc-trx.c)
(4) Variable type ktime_t and s64 (nrc-debug.c / h)