### PR TITLE
spi-ft232h: fix undefined LINUX_VERSION_CODE error

### DIFF
--- a/package/host/src/ft232h-usb-spi/drivers/spi/spi-ft232h/ft232h-intf.c
+++ b/package/host/src/ft232h-usb-spi/drivers/spi/spi-ft232h/ft232h-intf.c
@@ -23,6 +23,7 @@
 #include <linux/spi/spi.h>
 #include <linux/usb/ch9.h>
 #include <linux/usb.h>
+#include <linux/version.h>
 
 #include "ft232h-intf.h"
 


### PR DESCRIPTION
This fixes the following compiler error when building on Linux 5.10:

```
.../package/host/src/ft232h-usb-spi/drivers/spi/spi-ft232h/ft232h-intf.c: In function 'ftdi_mpsse_gpio_probe':
.../package/host/src/ft232h-usb-spi/drivers/spi/spi-ft232h/ft232h-intf.c:766:5: warning: "LINUX_VERSION_CODE" is not defined, evaluates to 0 [-Wundef]
  766 | #if LINUX_VERSION_CODE <= KERNEL_VERSION(5,7,19)
      |     ^~~~~~~~~~~~~~~~~~
.../package/host/src/ft232h-usb-spi/drivers/spi/spi-ft232h/ft232h-intf.c:766:27: warning: "KERNEL_VERSION" is not defined, evaluates to 0 [-Wundef]
  766 | #if LINUX_VERSION_CODE <= KERNEL_VERSION(5,7,19)
      |                           ^~~~~~~~~~~~~~
.../package/host/src/ft232h-usb-spi/drivers/spi/spi-ft232h/ft232h-intf.c:766:41: error: missing binary operator before token "("
  766 | #if LINUX_VERSION_CODE <= KERNEL_VERSION(5,7,19)
      |                                         ^
```
