### PR TITLE
Allow make variables to be passed in from the env

### DIFF
--- a/package/host/src/cli_app/Makefile
+++ b/package/host/src/cli_app/Makefile
@@ -1,6 +1,6 @@
-CC=gcc
-RM = rm -f
-LDFLAGS=-pthread -lm
+CC ?= gcc
+RM ?= rm -f
+LDFLAGS += -pthread -lm
 OBJS = cli_cmd.o cli_netlink.o cli_util.o main.o
 TARGET = cli_app
 


### PR DESCRIPTION
This makes it possible for cross-compilation tools to pass in additions
to LDFLAGS and an alternative CC from the environment. This preserves
the current behavior if the variables aren't set. If LDFLAGS is set
already, then the required libraries are appended to it.
