### PR TITLE
fix for Gateworks FTDI USB-SPI driver for designs w/out HSPI_EIRQ->GP…

### DIFF
--- a/package/host/src/nrc/nrc-hif-cspi.c
+++ b/package/host/src/nrc/nrc-hif-cspi.c
@@ -1308,8 +1308,10 @@ static int spi_poll_thread (void *data)
 	interval *= 1000;
 
 	while (!kthread_should_stop()) {
-		if (gpio < 0)
+		if (gpio < 0) {
 			spi_irq(-1, hdev);
+                        wake_up_interruptible(&priv->wait);
+                }
 		else {
 			ret = gpio_get_value_cansleep(gpio);
 


### PR DESCRIPTION
Adding a delayed-work wakeup in the SPI poll routine for hardware without the HSPI_EIRQ line tied to FTDI GPIO0. This fixes an RX thread stall that appears to cause timing issues in the nrc7292 firmware.

This fix worked for our pre-release hardware without the HSPI_EIRQ->GPIO0 line.