### PR TITLE
allow out-of-tree compile of Newracom FTDI SPi module

### DIFF
--- a/package/host/src/ft232h-usb-spi/Makefile
+++ b/package/host/src/ft232h-usb-spi/Makefile
@@ -2,8 +2,15 @@
 KDIR ?= /lib/modules/$(shell uname -r)/build
 MDIR ?= $(PWD)/drivers/spi
 
-all:
+include $(KDIR)/.config
+
+all: modules
+
+modules:
 	@$(MAKE) -C $(KDIR) M=$(MDIR) CONFIG_SPI_FT232H=m modules
+
+modules_install:
+	@$(MAKE) -C $(KDIR) M=$(MDIR) modules_install
 
 debug:
 	@$(MAKE) -C $(KDIR) M=$(MDIR) CONFIG_SPI_FT232H=m CONFIG_SPI_FT232H_DEBUG=y modules


### PR DESCRIPTION
Modify FTDI SPI module Makefile to allow cross-compiling out-of-tree. This is necessary when, for example, running a 64-bit Linux kernel on a Raspberry Pi for performance but a 32-bit Raspbian userspace for compatibility. Modules must be cross-compiled for this environment.