### PR TITLE
remove MODULE_SUPPORTED_DEVICE which has been deprecated by upstream

### DIFF
--- a/package/host/src/nrc/nrc-init.c
+++ b/package/host/src/nrc/nrc-init.c
@@ -683,4 +683,3 @@ module_exit(nrc_exit);
 MODULE_AUTHOR("Newracom, Inc.(http://www.newracom.com)");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Newracom 802.11 driver");
-MODULE_SUPPORTED_DEVICE("Newracom 802.11 devices");

--- a/package/host/src/nrc_hspi_simple/nrc_hspi_simple_driver.c
+++ b/package/host/src/nrc_hspi_simple/nrc_hspi_simple_driver.c
@@ -255,4 +255,3 @@ module_exit(nrc_exit);
 MODULE_AUTHOR("Newracom, Inc.(http://www.newracom.com)");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Newracom HSPI simple driver");
-MODULE_SUPPORTED_DEVICE("Newracom 802.11 devices");

--- a/package/host_kr_mic/src/nrc/nrc-init.c
+++ b/package/host_kr_mic/src/nrc/nrc-init.c
@@ -683,4 +683,3 @@ module_exit(nrc_exit);
 MODULE_AUTHOR("Newracom, Inc.(http://www.newracom.com)");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Newracom 802.11 driver");
-MODULE_SUPPORTED_DEVICE("Newracom 802.11 devices");

--- a/package/host_kr_mic/src/nrc_hspi_simple/nrc_hspi_simple_driver.c
+++ b/package/host_kr_mic/src/nrc_hspi_simple/nrc_hspi_simple_driver.c
@@ -255,4 +255,3 @@ module_exit(nrc_exit);
 MODULE_AUTHOR("Newracom, Inc.(http://www.newracom.com)");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Newracom HSPI simple driver");
-MODULE_SUPPORTED_DEVICE("Newracom 802.11 devices");

--- a/package/host_kr_usn/src/nrc/nrc-init.c
+++ b/package/host_kr_usn/src/nrc/nrc-init.c
@@ -683,4 +683,3 @@ module_exit(nrc_exit);
 MODULE_AUTHOR("Newracom, Inc.(http://www.newracom.com)");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Newracom 802.11 driver");
-MODULE_SUPPORTED_DEVICE("Newracom 802.11 devices");

--- a/package/host_kr_usn/src/nrc_hspi_simple/nrc_hspi_simple_driver.c
+++ b/package/host_kr_usn/src/nrc_hspi_simple/nrc_hspi_simple_driver.c
@@ -255,4 +255,3 @@ module_exit(nrc_exit);
 MODULE_AUTHOR("Newracom, Inc.(http://www.newracom.com)");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Newracom HSPI simple driver");
-MODULE_SUPPORTED_DEVICE("Newracom 802.11 devices");


### PR DESCRIPTION
According to Linux kernel upstream's commit:

https://github.com/torvalds/linux/commit/6417f03132a6952cd17ddd8eaddbac92b61b17e0

The MODULE_SUPPORTED_DEVICE has been removed from the mainline tree. It
means the module compilation will fail since v5.12. It's safe to drop it
since it's never implemented.

Signed-off-by: Chun-Yu Lee (Mat) <matlinuxer2@gmail.com>