### PR TITLE
Add channel argument support for start.py's AP mode

### DIFF
--- a/package/host/evk/sw_pkg/nrc_pkg/script/stop.py
+++ b/package/host/evk/sw_pkg/nrc_pkg/script/stop.py
@@ -25,6 +25,7 @@ time.sleep(1)
 print("[1] Remove module")
 os.system("sudo rmmod nrc")
 os.system("sudo rm "+script_path+"conf/temp_self_config.conf")
+os.system("sudo rm "+script_path+"conf/temp_hostapd_config.conf")
 time.sleep(2)
 
 print("[2] Done")


### PR DESCRIPTION
The original start.py's "[channel]" argument was only accepted in
sniffer mode("[sta_type]" is 2:SNIFFER). This patch add channel argument
support for ap mode("[sta_type]" is 1:AP), too. The feature make it
easier to test different channels without editing the hostapd conf file
each time.

Signed-off-by: Chun-Yu Lee (Mat) <matlinuxer2@gmail.com>