### PR TITLE
update driver for Linux kernel changes through 6.1.x, remove Makefile…

### DIFF
--- a/package/host/src/nrc/Makefile
+++ b/package/host/src/nrc/Makefile
@@ -2,7 +2,9 @@
 KDIR ?= /lib/modules/$(shell uname -r)/build
 CHECKPATCH ?= $(KDIR)/scripts/checkpatch.pl
 
+ifneq ("$(wildcard $(KDIR)/.config)","")
 include $(KDIR)/.config
+endif
 
 M_SRC = nrc
 

--- a/package/host/src/nrc/nrc-bd.c
+++ b/package/host/src/nrc/nrc-bd.c
@@ -464,12 +464,13 @@ static void * nrc_dump_load(int len)
 {
 	struct file *filp;
 	loff_t pos=0;
-	mm_segment_t old_fs;
 	char filepath[64];
 	char *buf = NULL;
 #if BD_DEBUG
 	int i;
 #endif
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
+	mm_segment_t old_fs;
 
 	sprintf(filepath, "/lib/firmware/%s", bd_name);
 #if KERNEL_VERSION(5,0,0) > NRC_TARGET_KERNEL_VERSION
@@ -481,14 +482,19 @@ static void * nrc_dump_load(int len)
 #else
 	old_fs = force_uaccess_begin();
 #endif
+#else
+	sprintf(filepath, "/lib/firmware/%s", bd_name);
+#endif
 
 	filp = filp_open(filepath, O_RDONLY, 0);
 	if (IS_ERR(filp)) {
 		pr_err("Failed to load board data, error:%d",IS_ERR(filp));
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
 #if KERNEL_VERSION(5,10,0) > NRC_TARGET_KERNEL_VERSION
 	set_fs(old_fs);
 #else
 	force_uaccess_end(old_fs);
+#endif
 #endif
 		return NULL;
 	}
@@ -506,10 +512,12 @@ static void * nrc_dump_load(int len)
 #endif
 
 	filp_close(filp, NULL);
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
 #if KERNEL_VERSION(5,10,0) > NRC_TARGET_KERNEL_VERSION
 	set_fs(old_fs);
 #else
 	force_uaccess_end(old_fs);
+#endif
 #endif
 
 #if BD_DEBUG
@@ -739,9 +747,10 @@ int nrc_check_bd(void)
 	char *buf;
 	size_t length;
 	int ret;
-	mm_segment_t old_fs;
 	char filepath[64];
-
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
+	mm_segment_t old_fs;
+	
 	sprintf(filepath, "/lib/firmware/%s", bd_name);
 #if KERNEL_VERSION(5,0,0) > NRC_TARGET_KERNEL_VERSION
 	old_fs = get_fs();
@@ -752,14 +761,19 @@ int nrc_check_bd(void)
 #else
 	old_fs = force_uaccess_begin();
 #endif
-
+#else
+	sprintf(filepath, "/lib/firmware/%s", bd_name);
+#endif
+	
 	filp = filp_open(filepath, O_RDONLY, 0);
 	if (IS_ERR(filp)) {
 		pr_err("Failed to load board data :error: %d",IS_ERR(filp));
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
 #if KERNEL_VERSION(5,10,0) > NRC_TARGET_KERNEL_VERSION
 		set_fs(old_fs);
 #else
 		force_uaccess_end(old_fs);
+#endif
 #endif
 		return -EIO;
 	}
@@ -792,10 +806,12 @@ int nrc_check_bd(void)
 	g_bd_size = kernel_read(filp, pos, buf, (int)length);
 #endif
 	filp_close(filp, NULL);
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
 #if KERNEL_VERSION(5,10,0) > NRC_TARGET_KERNEL_VERSION
 	set_fs(old_fs);
 #else
 	force_uaccess_end(old_fs);
+#endif
 #endif
 	kfree(stat);
 

--- a/package/host/src/nrc/nrc-dump.c
+++ b/package/host/src/nrc/nrc-dump.c
@@ -27,8 +27,8 @@
 static void write_file(char *filename, char *data, int len)
 {
 	struct file *filp;
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
 	mm_segment_t old_fs;
-
 #if KERNEL_VERSION(5,0,0) > NRC_TARGET_KERNEL_VERSION
 	old_fs = get_fs();
 	set_fs( get_ds() );
@@ -37,6 +37,7 @@ static void write_file(char *filename, char *data, int len)
 	set_fs( KERNEL_DS );
 #else
 	old_fs = force_uaccess_begin();
+#endif
 #endif
 	filp = filp_open(filename, O_CREAT|O_RDWR, 0606);
 	if (IS_ERR(filp)) {
@@ -50,10 +51,12 @@ static void write_file(char *filename, char *data, int len)
 #endif
 
 	filp_close(filp, NULL);
+#if NRC_TARGET_KERNEL_VERSION < KERNEL_VERSION(5,19,0)
 #if KERNEL_VERSION(5,10,0) > NRC_TARGET_KERNEL_VERSION
 	set_fs(old_fs);
 #else
 	force_uaccess_end(old_fs);
+#endif
 #endif
 }
 

--- a/package/host/src/nrc/nrc-hif-cspi.c
+++ b/package/host/src/nrc/nrc-hif-cspi.c
@@ -2215,7 +2215,7 @@ static int c_spi_remove(struct spi_device *spi)
 
 static struct spi_driver spi_driver = {
 	.probe = c_spi_probe,
-	.remove = c_spi_remove,
+	.remove = (void*) c_spi_remove,
 	.driver = {
 		.name = "nrc-cspi",
 	},
@@ -2226,6 +2226,52 @@ static struct spi_board_info bi = {
 //	.chip_select = 0,
 	.mode = SPI_MODE_0,
 };
+
+#if NRC_TARGET_KERNEL_VERSION >= KERNEL_VERSION(5,16,0)
+#include <linux/platform_device.h>
+static int __spi_controller_match(struct device *dev, const void *data)
+{
+	struct spi_controller *ctlr;
+	const u16 *bus_num = data;
+
+	ctlr = container_of(dev, struct spi_controller, dev);
+	
+	if(!ctlr) {
+		return 0;
+	}
+	
+	return ctlr->bus_num == *bus_num;
+}
+
+static struct spi_controller *spi_busnum_to_master(u16 bus_num)
+{
+	struct platform_device *pdev = NULL;
+	struct spi_master *master = NULL;
+	struct spi_controller *ctlr = NULL;
+	struct device *dev = NULL;
+	
+	pdev = platform_device_alloc("pdev", PLATFORM_DEVID_NONE);
+	pdev->num_resources = 0;
+	platform_device_add(pdev);
+	
+	master = spi_alloc_master(&pdev->dev, sizeof(void *));
+	if (!master) {
+		pr_err("Error: failed to allocate SPI master device\n");
+		platform_device_put(pdev);
+		return NULL;
+	}
+    
+	dev = class_find_device(master->dev.class, NULL, &bus_num, __spi_controller_match);
+	if (dev) {
+		ctlr = container_of(dev, struct spi_controller, dev);
+	}
+	
+	spi_master_put(master);
+	platform_device_put(pdev);
+	
+	return ctlr;
+}
+#endif
 
 struct nrc_hif_device *nrc_hif_cspi_init(void)
 {

--- a/package/host/src/nrc/nrc-netlink.c
+++ b/package/host/src/nrc/nrc-netlink.c
@@ -455,7 +455,11 @@ static int halow_set_dut(struct sk_buff *skb, struct genl_info *info)
 #endif
 			skb_set_queue_mapping(b, IEEE80211_AC_VO);
 #ifdef CONFIG_SUPPORT_CHANNEL_INFO
+#if ((KERNEL_VERSION(5, 19, 2) <= NRC_TARGET_KERNEL_VERSION))
+			chanctx_conf = rcu_dereference(vif->bss_conf.chanctx_conf);
+#else
 			chanctx_conf = rcu_dereference(vif->chanctx_conf);
+#endif
 			band = chanctx_conf->def.chan->band;
 
 			if (!ieee80211_tx_prepare_skb(nrc_nw->hw,
@@ -1041,7 +1045,11 @@ static void generate_mmic_error(void *data, u8 *mac, struct ieee80211_vif *vif)
 	rx_status = IEEE80211_SKB_RXCB(skb);
 
 #ifdef CONFIG_SUPPORT_CHANNEL_INFO
+#if ((KERNEL_VERSION(5, 19, 2) <= NRC_TARGET_KERNEL_VERSION))
+	chan = rcu_dereference(vif->bss_conf.chanctx_conf);
+#else
 	chan = rcu_dereference(vif->chanctx_conf);
+#endif
 	if (!chan)
 		goto out;
 

--- a/package/host/src/nrc/nrc-pm.c
+++ b/package/host/src/nrc/nrc-pm.c
@@ -321,7 +321,11 @@ static void sta_max_idle_period_expire(struct timer_list *t)
 	skb_set_queue_mapping(skb, IEEE80211_AC_VO);
 
 #ifdef CONFIG_SUPPORT_CHANNEL_INFO
+#if ((KERNEL_VERSION(5, 19, 2) <= NRC_TARGET_KERNEL_VERSION))
+	chanctx_conf = rcu_dereference(i_sta->vif->bss_conf.chanctx_conf);
+#else
 	chanctx_conf = rcu_dereference(i_sta->vif->chanctx_conf);
+#endif
 	if (!chanctx_conf)
 		goto drop;
 

--- a/package/host/src/nrc/nrc-ssp.c
+++ b/package/host/src/nrc/nrc-ssp.c
@@ -559,7 +559,7 @@ static int ssp_remove(struct spi_device *spi)
 
 static struct spi_driver ssp_driver = {
 	.probe	= ssp_probe,
-	.remove = ssp_remove,
+	.remove = (void*)ssp_remove,
 	.driver = {
 		.name = "nrc-nspi",
 	},
@@ -570,6 +570,52 @@ static struct spi_board_info bi = {
 	.chip_select = 0,
 	.mode = SPI_MODE_1,
 };
+
+#if NRC_TARGET_KERNEL_VERSION >= KERNEL_VERSION(5,16,0)
+#include <linux/platform_device.h>
+static int __spi_controller_match(struct device *dev, const void *data)
+{
+	struct spi_controller *ctlr;
+	const u16 *bus_num = data;
+
+	ctlr = container_of(dev, struct spi_controller, dev);
+	
+	if(!ctlr) {
+		return 0;
+	}
+	
+	return ctlr->bus_num == *bus_num;
+}
+
+static struct spi_controller *spi_busnum_to_master(u16 bus_num)
+{
+	struct platform_device *pdev = NULL;
+	struct spi_master *master = NULL;
+	struct spi_controller *ctlr = NULL;
+	struct device *dev = NULL;
+	
+	pdev = platform_device_alloc("pdev", PLATFORM_DEVID_NONE);
+	pdev->num_resources = 0;
+	platform_device_add(pdev);
+	
+	master = spi_alloc_master(&pdev->dev, sizeof(void *));
+	if (!master) {
+		pr_err("Error: failed to allocate SPI master device\n");
+		platform_device_put(pdev);
+		return NULL;
+	}
+    
+	dev = class_find_device(master->dev.class, NULL, &bus_num, __spi_controller_match);
+	if (dev) {
+		ctlr = container_of(dev, struct spi_controller, dev);
+	}
+	
+	spi_master_put(master);
+	platform_device_put(pdev);
+	
+	return ctlr;
+}
+#endif
 
 int nrc_ssp_register(struct nrc_hif_ssp *hif)
 {


### PR DESCRIPTION
This changeset updates the nrc7292 V1.34 rev14 driver to be compatible through the 6.1.x kernel series. 

The function spi_busnum_to_master was removed in kernel 5.16.

The mac80211 interface changed in kernel 5.19.2.

 The get_fs(), set_fs(), and get_ds() are no longer needed or available in kernel 5.19 and newer.

The Makefile was updated to remove a dependency on .config if this file does not exist. This line breaks DKMS compilation on Debian and Ubuntu.